### PR TITLE
v1.2.0: update normalizing flow latent handing, update docs, model versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,18 @@ This project uses **two independent version numbers**:
 
 ---
 
+## [1.2.0] — 2026-05-11 (package) | Model: v1.1.0
+
+### Added
+- `NormalizingFlow.get_latent_representation()` now supports v1.0.0 weights via a `legacy_v1_0_0` path: pushes a zero vector through the forward transform (deterministic) rather than sampling from the conditional base distribution. `NormalizingFlow.load()` auto-detects the version from saved metadata and sets the flag automatically, so v1.0.0 and v1.1.0 inference are both correct without user intervention.
+- `docs/model_versions.rst` — new reference page documenting all ISEFlow weight versions, per-version input schemas, migration guides (v1.0.0 → v1.1.0), `from_absolute_forcings()` usage, and weight resolution order. Linked from `docs/index.rst`.
+- `examples/recreate_manuscript_results.py` — end-to-end script that downloads v1.0.0 test splits and scalers from HuggingFace Hub (`pvankatwyk/iseflow-datasets`), runs inference with v1.0.0 pretrained weights, and reports held-out MSE for both AIS and GrIS.
+
+### Changed
+- `NormalizingFlow.get_latent_representation()` docstring expanded to document both the legacy deterministic path (v1.0.0) and the stochastic sampling path (v1.1.0+), including the behavioural difference and its downstream effect on `DeepEnsemble` inputs.
+
+---
+
 ## [1.1.0] — 2026-05-08 (package) | Model: v1.1.0
 
 ### Added

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -164,4 +164,5 @@ If you use ISE in research, please consider citing our work.  See
    :caption: Contents:
 
    quickstart
+   model_versions
    docs/source/ise

--- a/docs/model_versions.rst
+++ b/docs/model_versions.rst
@@ -31,14 +31,21 @@ v1.1.0 — AIS + GrIS (current)
 
 **What changed from v1.0.0**
 
-- **GrIS support added.** First release of ``ISEFlow_GrIS`` pretrained weights covering
-  all 6 Greenland drainage basins.
 - **``mrro_anomaly`` removed from AIS inputs.** The melt-runoff anomaly variable was
   dropped from the AIS feature set after ablation analysis showed it contributed noise
   rather than signal.  Code using v1.0.0-style inputs that passes ``mrro_anomaly`` must
   remove it before calling ``predict()`` with v1.1.0 weights.
 - Scalers saved alongside weights per ice sheet and version so that
   ``predict(..., output_scaler=True)`` works correctly for both AIS and GrIS.
+- **NormalizingFlow architecture upgraded.** The context encoder was changed from a
+  single ``nn.Linear(input_size, output_size * 2)`` layer to a 2-layer MLP
+  (``Linear → ReLU → Linear``), and ``flow_hidden_features`` is now a tunable
+  hyperparameter rather than being hard-coded to ``output_size * 2``.
+- **``get_latent`` changed from deterministic to stochastic.** v1.0.0 pushed a fixed
+  zero vector through the forward transform to produce latents; v1.1.0 draws samples
+  from the conditional base distribution instead.  Both approaches are preserved —
+  ``NormalizingFlow.load()`` auto-detects the version from saved metadata and sets
+  ``legacy_v1_0_0=True`` for old weights so inference reproduces the original latents.
 
 **AIS inputs (v1.1.0)**
 

--- a/docs/model_versions.rst
+++ b/docs/model_versions.rst
@@ -67,12 +67,12 @@ v1.1.0 — AIS + GrIS (current)
 
 ---
 
-v1.0.0 — AIS only (legacy)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+v1.0.0 — AIS + GrIS (legacy)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :Released: 2026-05-07
-:Ice sheets: AIS (18 sectors) only
-:Classes: ``ISEFlow_AIS(version="v1.0.0")``
+:Ice sheets: AIS (18 sectors), GrIS (6 drainage basins)
+:Classes: ``ISEFlow_AIS(version="v1.0.0")``, ``ISEFlow_GrIS(version="v1.0.0")``
 
 The original pretrained release.  Maintained for reproducibility of results from the
 ISEFlow manuscript.

--- a/docs/model_versions.rst
+++ b/docs/model_versions.rst
@@ -1,0 +1,179 @@
+ISEFlow Model Versions
+======================
+
+ISEFlow pretrained weights are versioned independently from the ``ise-py`` package.
+Weights are hosted on HuggingFace Hub at ``pvankatwyk/ISEFlow`` and downloaded
+automatically on first use.  Local bundled fallback weights are used when HuggingFace
+is unavailable (air-gapped HPC, offline development).
+
+Use the ``version`` argument when loading a pretrained model:
+
+.. code-block:: python
+
+   from ise.models import ISEFlow_AIS, ISEFlow_GrIS
+
+   model = ISEFlow_AIS(version="v1.1.0")   # latest
+   model = ISEFlow_AIS(version="v1.0.0")   # legacy AIS-only weights
+
+Current recommended version: **v1.1.0**
+
+---
+
+Version history
+---------------
+
+v1.1.0 — AIS + GrIS (current)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Released: 2026-05-08
+:Ice sheets: AIS (18 sectors), GrIS (6 drainage basins)
+:Classes: ``ISEFlow_AIS(version="v1.1.0")``, ``ISEFlow_GrIS(version="v1.1.0")``
+
+**What changed from v1.0.0**
+
+- **GrIS support added.** First release of ``ISEFlow_GrIS`` pretrained weights covering
+  all 6 Greenland drainage basins.
+- **``mrro_anomaly`` removed from AIS inputs.** The melt-runoff anomaly variable was
+  dropped from the AIS feature set after ablation analysis showed it contributed noise
+  rather than signal.  Code using v1.0.0-style inputs that passes ``mrro_anomaly`` must
+  remove it before calling ``predict()`` with v1.1.0 weights.
+- Scalers saved alongside weights per ice sheet and version so that
+  ``predict(..., output_scaler=True)`` works correctly for both AIS and GrIS.
+
+**AIS inputs (v1.1.0)**
+
+.. code-block:: text
+
+   year, sector,
+   pr_anomaly, evspsbl_anomaly, smb_anomaly, ts_anomaly,
+   ocean_thermal_forcing, ocean_salinity, ocean_temperature,
+   ice_shelf_fracture, ocean_sensitivity, ocean_forcing_type, standard_melt_type,
+   [ISM model characteristics]
+
+**GrIS inputs (v1.1.0)**
+
+.. code-block:: text
+
+   year, region,
+   smb_anomaly, st_anomaly, ocean_thermal_forcing, basin_runoff,
+   [ISM model characteristics]
+
+---
+
+v1.0.0 — AIS only (legacy)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Released: 2026-05-07
+:Ice sheets: AIS (18 sectors) only
+:Classes: ``ISEFlow_AIS(version="v1.0.0")``
+
+The original pretrained release.  Maintained for reproducibility of results from the
+ISEFlow manuscript.
+
+**AIS inputs (v1.0.0)**
+
+Identical to v1.1.0 **plus** ``mrro_anomaly`` (melt-runoff anomaly):
+
+.. code-block:: text
+
+   year, sector,
+   pr_anomaly, evspsbl_anomaly, smb_anomaly, ts_anomaly, mrro_anomaly,
+   ocean_thermal_forcing, ocean_salinity, ocean_temperature,
+   ice_shelf_fracture, ocean_sensitivity, ocean_forcing_type, standard_melt_type,
+   [ISM model characteristics]
+
+.. note::
+   ``ISEFlow_AIS(version="v1.0.0")`` and ``ISEFlow_GrIS(version="v1.0.0")`` are still
+   loadable as of package v1.1.0.  The ``NormalizingFlow`` loader auto-detects the older
+   architecture from saved metadata.  ``ISEFlow_GrIS_DE/NF_v1_0_0`` emit a
+   ``DeprecationWarning`` on instantiation.
+
+---
+
+Migrating between versions
+---------------------------
+
+v1.0.0 → v1.1.0 (AIS)
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Remove ``mrro_anomaly`` from your ``ISEFlowAISInputs`` constructor call and switch the
+``version`` argument:
+
+.. code-block:: python
+
+   # v1.0.0 style — no longer valid for v1.1.0
+   inputs = ISEFlowAISInputs(
+       ...,
+       mrro_anomaly=mrro,   # remove this line
+   )
+   model = ISEFlow_AIS(version="v1.0.0")
+
+   # v1.1.0 style
+   inputs = ISEFlowAISInputs(
+       year=year,
+       sector=sector,
+       pr_anomaly=pr,
+       evspsbl_anomaly=evspsbl,
+       smb_anomaly=smb,
+       ts_anomaly=ts,
+       ocean_thermal_forcing=otf,
+       ocean_salinity=sal,
+       ocean_temperature=temp,
+       model_configs="AWI_PISM1",
+       ice_shelf_fracture=False,
+       ocean_sensitivity="medium",
+       ocean_forcing_type="standard",
+       standard_melt_type="local",
+   )
+   model = ISEFlow_AIS(version="v1.1.0")
+
+Using absolute forcings instead of anomalies
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you have raw absolute climate values rather than pre-computed anomalies, use the
+``from_absolute_forcings()`` classmethod.  Pass ``aogcm`` for a bundled CMIP model or
+``custom_climatology`` for a new model not in the bundled set:
+
+.. code-block:: python
+
+   inputs = ISEFlowAISInputs.from_absolute_forcings(
+       year=year,
+       sector=sector,
+       pr=pr_abs,
+       evspsbl=evspsbl_abs,
+       smb=smb_abs,
+       ts=ts_abs,
+       ocean_thermal_forcing=otf,
+       ocean_salinity=sal,
+       ocean_temperature=temp,
+       aogcm="MIROC6",          # or custom_climatology={...}
+       model_configs="AWI_PISM1",
+       ice_shelf_fracture=False,
+       ocean_sensitivity="medium",
+       ocean_forcing_type="standard",
+       standard_melt_type="local",
+   )
+
+.. note::
+   ``from_raw_values()`` is a deprecated alias for ``from_absolute_forcings()`` and will
+   be removed in a future release.
+
+---
+
+Weight resolution
+-----------------
+
+The path resolution order is:
+
+1. HuggingFace Hub (``pvankatwyk/ISEFlow``) — downloaded on first use and cached locally.
+2. Bundled local weights under ``ise/models/pretrained/ISEFlow/`` — used automatically
+   when HuggingFace is unreachable.
+
+Use ``get_model_dir(version, ice_sheet)`` (from ``ise.models.pretrained``) to resolve
+the path programmatically.  Do not use the deprecated ``_path`` constants.
+
+.. code-block:: python
+
+   from ise.models.pretrained import get_model_dir
+
+   path = get_model_dir("v1.1.0", "AIS")

--- a/examples/recreate_manuscript_results.py
+++ b/examples/recreate_manuscript_results.py
@@ -1,4 +1,4 @@
-"""Validate ISEFlow v1.0.0 weights against paper-reported test-set MSE.
+"""Validate ISEFlow (v1.0.0 and v1.1.0) Manuscript Results.
 
 This script reproduces the held-out test-set evaluation reported for ISEFlow
 v1.0.0. It downloads the v1.0.0 test splits and scalers from HuggingFace Hub

--- a/examples/validate_v1_0_0.py
+++ b/examples/validate_v1_0_0.py
@@ -77,4 +77,4 @@ for ice_sheet in ("AIS", "GrIS"):
 
         preds, _ = model.predict(X_test)
         mse = np.mean((y_test - preds) ** 2)
-        print(f"{ice_sheet} MSE: {mse:.4f}  (expected: AIS ~1.20, GrIS ~1.02)")
+        print(f"{ice_sheet} MSE: {mse:.4f}  (expected: V1.0.0 AIS ~1.20, GrIS ~1.02)")

--- a/examples/validate_v1_0_0.py
+++ b/examples/validate_v1_0_0.py
@@ -1,0 +1,80 @@
+"""Validate ISEFlow v1.0.0 weights against paper-reported test-set MSE.
+
+This script reproduces the held-out test-set evaluation reported for ISEFlow
+v1.0.0. It downloads the v1.0.0 test splits and scalers from HuggingFace Hub
+(cached after first download) and evaluates against pretrained v1.0.0 weights.
+
+Key difference from v1.1.0
+--------------------------
+ISEFlow v1.0.0 includes ``mrro_anomaly`` (meltwater runoff anomaly) as an
+active input feature for AIS. This variable was removed in v1.1.0 due to
+inconsistent availability across CMIP models. The v1.0.0 test splits and
+scalers therefore have a different column count than v1.1.0.
+
+Data
+----
+Test splits and scalers are downloaded from:
+  https://huggingface.co/datasets/pvankatwyk/iseflow-datasets  (v1.0.0/)
+
+Weights are resolved via ``get_model_dir("v1.0.0", ice_sheet)`` and
+downloaded from ``pvankatwyk/ISEFlow`` on HuggingFace Hub if not cached.
+"""
+
+import os
+import tempfile
+
+import numpy as np
+from huggingface_hub import hf_hub_download
+
+from ise.models.deep_ensemble import DeepEnsemble
+from ise.models.iseflow import ISEFlow
+from ise.models.normalizing_flow import NormalizingFlow
+from ise.models.pretrained import get_model_dir
+from ise.utils.functions import get_data, unscale_output
+
+DATASET_REPO = "pvankatwyk/iseflow-datasets"
+
+# ── 1. Evaluate each ice sheet ────────────────────────────────────────────────
+#
+# For each ice sheet we download the held-out test split and scaler from
+# HuggingFace, stage them in a temp directory that matches the layout expected
+# by get_data(), then run inference with the v1.0.0 weights and print MSE.
+
+for ice_sheet in ("AIS", "GrIS"):
+    prefix = f"v1.0.0/{ice_sheet}"
+
+    # ── 2. Download test split and scaler from HuggingFace Hub ────────────────
+
+    with tempfile.TemporaryDirectory() as data_dir:
+        for filename, dest in [
+            (f"{prefix}/test.csv", "test.csv"),
+            (f"{prefix}/train.csv", "train.csv"),  # get_data needs all splits present
+            (f"{prefix}/val.csv", "val.csv"),
+            (f"{prefix}/scalers/scaler_X.pkl", "scaler_X.pkl"),
+            (f"{prefix}/scalers/scaler_y.pkl", "scaler_y.pkl"),
+        ]:
+            local_path = hf_hub_download(
+                repo_id=DATASET_REPO,
+                filename=filename,
+                repo_type="dataset",
+            )
+            os.symlink(local_path, os.path.join(data_dir, dest))
+
+        # ── 3. Load test split ────────────────────────────────────────────────
+
+        _, _, _, _, X_test, y_test = get_data(data_dir, return_format="numpy")
+        y_test = unscale_output(y_test.reshape(-1, 1), os.path.join(data_dir, "scaler_y.pkl"))
+
+        # ── 4. Load pretrained v1.0.0 weights ─────────────────────────────────
+
+        model_dir = get_model_dir("v1.0.0", ice_sheet)
+        de = DeepEnsemble.load(f"{model_dir}/deep_ensemble.pth")
+        nf = NormalizingFlow.load(f"{model_dir}/normalizing_flow.pth")
+        model = ISEFlow(de, nf)
+        model.model_dir = model_dir
+
+        # ── 5. Predict and compute MSE ────────────────────────────────────────
+
+        preds, _ = model.predict(X_test)
+        mse = np.mean((y_test - preds) ** 2)
+        print(f"{ice_sheet} MSE: {mse:.4f}  (expected: AIS ~1.20, GrIS ~1.02)")

--- a/ise/models/normalizing_flow.py
+++ b/ise/models/normalizing_flow.py
@@ -368,19 +368,41 @@ class NormalizingFlow(nn.Module):
         """
         Computes the latent space representation of the given input.
 
+        Two approaches are used depending on the model version:
+
+        - **v1.0.0 (legacy)**: deterministically pushes a zero vector through the
+          forward transform conditioned on ``x``. Same ``x`` always yields the same
+          ``z``, so the flow acts as a learned deterministic feature extractor.
+        - **v1.1.0+ (default)**: draws ``latent_dim`` samples from the conditional
+          base distribution. ``z`` is a stochastic summary of ``x``, which is more
+          statistically grounded — the latent reflects the modeled conditional
+          distribution rather than a single fixed point.
+
+        These approaches behave differently and produce different downstream
+        DeepEnsemble inputs; the choice may be worth revisiting in future versions.
+        The legacy path is more pragmatic and reproducible at inference, while the
+        sampling path aligns more closely with the probabilistic interpretation of
+        the flow.
+
         Args:
             x (array-like or torch.Tensor): Input data of shape (num_samples, num_features).
-            latent_constant (float, optional): Constant value used for latent variable sampling. Defaults to 0.0.
+            latent_dim (int, optional): Number of latent samples to draw (post-v1.0.0). Defaults to 1.
 
         Returns:
             torch.Tensor: Latent space representation of the input data.
         """
 
         x = to_tensor(x).to(self.device)
-        z = self.base_distribution.sample(latent_dim, context=x).squeeze(
-            2
-        )  # collapse third 1-d dimension
-        return z
+
+        if self.legacy_v1_0_0:
+            # v1.0.0 deterministically pushed a zero vector through the forward
+            # transform conditioned on x. The DeepEnsemble was trained on these
+            # latents, so inference must reproduce the same operation.
+            latent_constant_tensor = torch.zeros((x.shape[0], 1), device=self.device)
+            z, _ = self.t(latent_constant_tensor.float(), context=x)
+            return z
+
+        return self.base_distribution.sample(latent_dim, context=x).squeeze(2)
 
     def aleatoric(self, features, num_samples, batch_size=128):
         """


### PR DESCRIPTION
## [1.2.0] — 2026-05-11 (package) | Model: v1.1.0

### Added
- `NormalizingFlow.get_latent_representation()` now supports v1.0.0 weights via a `legacy_v1_0_0` path: pushes a zero vector through the forward transform (deterministic) rather than sampling from the conditional base distribution. `NormalizingFlow.load()` auto-detects the version from saved metadata and sets the flag automatically, so v1.0.0 and v1.1.0 inference are both correct without user intervention.
- `docs/model_versions.rst` — new reference page documenting all ISEFlow weight versions, per-version input schemas, migration guides (v1.0.0 → v1.1.0), `from_absolute_forcings()` usage, and weight resolution order. Linked from `docs/index.rst`.
- `examples/recreate_manuscript_results.py` — end-to-end script that downloads v1.0.0 test splits and scalers from HuggingFace Hub (`pvankatwyk/iseflow-datasets`), runs inference with v1.0.0 pretrained weights, and reports held-out MSE for both AIS and GrIS.

### Changed
- `NormalizingFlow.get_latent_representation()` docstring expanded to document both the legacy deterministic path (v1.0.0) and the stochastic sampling path (v1.1.0+), including the behavioural difference and its downstream effect on `DeepEnsemble` inputs.
