### PR TITLE
update citation and docs, minor bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -198,3 +198,4 @@ main.ipynb
 CLAUDE.md
 .claude
 .plan.md
+.bugs.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,19 @@ This project uses **two independent version numbers**:
 ### Fixed
 - Silenced `sklearn.exceptions.InconsistentVersionWarning` package-wide. Bundled pretrained scalers were pickled with an older sklearn version but unpickle correctly; the warning was noise on every example run. Filter installed in `ise/__init__.py` next to the existing properscoring escape-sequence filter.
 - `feature_engineer.scale_data()` and `FeatureEngineer.scale_data()` leaked file handles by calling `pickle.load(open(...))` without a context manager — switched to `with open(...) as f` to close deterministically and clear `ResourceWarning` noise.
+- `from ise import ISEFlow, ISEFlow_AIS, ISEFlow_GrIS` now works. The top-level `__all__` listed these names but never imported them, so the imports failed with `ImportError`. Added the imports from `ise.models`.
+
+### Documentation
+- Full audit pass across `ise/` docstrings. Notable fixes:
+  - `ISEFlow.forward` removed a phantom `smooth_projection` argument that did not exist in the signature.
+  - `ISEFlow.predict` converted a misleading `Raises: Warning` clause into a proper Sphinx `Warns` block and expanded the description of how scaler resolution and smoothing interact.
+  - `ISEFlow.load` removed a stale `Raises: NotImplementedError` claim that no longer matched the implementation.
+  - `NormalizingFlow.fit` documented the previously undocumented `X_val`, `y_val`, `lr`, and `wd` arguments.
+  - `NormalizingFlow.aleatoric` corrected the return-shape claim (per-row std `(N,)`, not `(num_samples,)`).
+  - `LSTM.fit` added the previously undocumented `wandb_run` argument.
+  - `RobustScaler.save/load` and `LogScaler.save/load` gained docstrings (only `StandardScaler` had them).
+  - `unscale_output` / `unscale_input` corrected: they accept any sklearn scaler with `inverse_transform`, not only `MinMaxScaler`.
+- `docs/model_versions.rst`: corrected the GrIS v1.1.0 input list (`aSMB`, `aST`, `sector`, etc. — not the prior `smb_anomaly`, `st_anomaly`, `region` placeholder), and replaced an unverified `aogcm="MIROC6"` example with a real bundled name (`noresm1-m_rcp85`).
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ This project uses **two independent version numbers**:
 
 ## [Unreleased]
 
+### Added
+- `docs/index.rst` — PyPI, Python version, License, and CI badges to match `README.md`. Previously only the ReadTheDocs badge was shown.
+
 ---
 
 ## [1.2.0] — 2026-05-11 (package) | Model: v1.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@ This project uses **two independent version numbers**:
 - Silenced `sklearn.exceptions.InconsistentVersionWarning` package-wide. Bundled pretrained scalers were pickled with an older sklearn version but unpickle correctly; the warning was noise on every example run. Filter installed in `ise/__init__.py` next to the existing properscoring escape-sequence filter.
 - `feature_engineer.scale_data()` and `FeatureEngineer.scale_data()` leaked file handles by calling `pickle.load(open(...))` without a context manager — switched to `with open(...) as f` to close deterministically and clear `ResourceWarning` noise.
 - `from ise import ISEFlow, ISEFlow_AIS, ISEFlow_GrIS` now works. The top-level `__all__` listed these names but never imported them, so the imports failed with `ImportError`. Added the imports from `ise.models`.
+- `ISEFlowGrISInputs._assign_model_configs` defaulted to the **AIS** model-configs JSON, so passing a GrIS-only ISM name (e.g. `model_configs="AWI-ISSM1"`) raised `ValueError: Model name ... not found`. Added a new `gris_ismip6_model_configs_path` constant in `ise/utils/__init__.py` pointing at `GrIS_ismip6_model_configs.json` and switched the GrIS dataclass to use it as the default. Regression test added.
+- `unscale_output()` / `unscale_input()` in `ise/utils/functions.py` leaked file handles via `pkl.load(open(...))` — switched to a `with open(...) as f` context manager (same pattern as the recent `feature_engineer` fix).
+- Replaced a bare `except:` clause in `ise.utils.functions.load_ml_data` with `except FileNotFoundError:` so that `KeyboardInterrupt`, `SystemExit`, and `MemoryError` are no longer silently swallowed.
+
+### Changed
+- `ProjectionProcessor` ocean-forcing warnings (AIS and GrIS) now list the directory, the expected NetCDF variable names, and the files that *were* found, instead of an opaque "Directory X does not contain N files." message.
+- Moved the in-body `from scipy.ndimage import uniform_filter1d` to the top of `ise/models/iseflow.py` next to the other module imports (style cleanup; PEP 8 E402).
 
 ### Documentation
 - Full audit pass across `ise/` docstrings. Notable fixes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ This project uses **two independent version numbers**:
   - `unscale_output` / `unscale_input` corrected: they accept any sklearn scaler with `inverse_transform`, not only `MinMaxScaler`.
 - `docs/model_versions.rst`: corrected the GrIS v1.1.0 input list (`aSMB`, `aST`, `sector`, etc. — not the prior `smb_anomaly`, `st_anomaly`, `region` placeholder), and replaced an unverified `aogcm="MIROC6"` example with a real bundled name (`noresm1-m_rcp85`).
 - `.gitignore`: ignore `.bugs.md` (local bug-triage scratchpad produced during the docs audit).
+- `README.md` and `docs/index.rst`: replaced the GitHub Releases pointer with a dedicated **Manuscript code archives** section listing Zenodo DOIs for each publication (Variational LSTM, ISEFlow, and the in-review "Emulator-expanded projections" paper). Reflects the move from per-paper GitHub releases to the maintained `ise-py` package plus frozen Zenodo snapshots.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,35 +13,30 @@ This project uses **two independent version numbers**:
 
 ## [Unreleased]
 
+---
+
+## [1.2.1] — 2026-05-13 (package) | Model: v1.1.0
+
 ### Added
-- `docs/index.rst` — PyPI, Python version, License, and CI badges to match `README.md`. Previously only the ReadTheDocs badge was shown.
-- `ise.models.pretrained.get_model_dir()` now prints a clear stderr message when ISEFlow weights are being downloaded from HuggingFace Hub for the first time (and another when the download finishes). When weights are already cached, the loader stays silent — previously the call could appear to hang while HF metadata sync ran.
+- `docs/index.rst` — PyPI, Python version, License, and CI badges to match `README.md`.
+- `ise.models.pretrained.get_model_dir()` prints stderr progress when ISEFlow weights are downloaded from HuggingFace Hub for the first time; stays silent on cached loads (previously could appear to hang during HF metadata sync).
 
 ### Fixed
-- Silenced `sklearn.exceptions.InconsistentVersionWarning` package-wide. Bundled pretrained scalers were pickled with an older sklearn version but unpickle correctly; the warning was noise on every example run. Filter installed in `ise/__init__.py` next to the existing properscoring escape-sequence filter.
-- `feature_engineer.scale_data()` and `FeatureEngineer.scale_data()` leaked file handles by calling `pickle.load(open(...))` without a context manager — switched to `with open(...) as f` to close deterministically and clear `ResourceWarning` noise.
-- `from ise import ISEFlow, ISEFlow_AIS, ISEFlow_GrIS` now works. The top-level `__all__` listed these names but never imported them, so the imports failed with `ImportError`. Added the imports from `ise.models`.
-- `ISEFlowGrISInputs._assign_model_configs` defaulted to the **AIS** model-configs JSON, so passing a GrIS-only ISM name (e.g. `model_configs="AWI-ISSM1"`) raised `ValueError: Model name ... not found`. Added a new `gris_ismip6_model_configs_path` constant in `ise/utils/__init__.py` pointing at `GrIS_ismip6_model_configs.json` and switched the GrIS dataclass to use it as the default. Regression test added.
-- `unscale_output()` / `unscale_input()` in `ise/utils/functions.py` leaked file handles via `pkl.load(open(...))` — switched to a `with open(...) as f` context manager (same pattern as the recent `feature_engineer` fix).
-- Replaced a bare `except:` clause in `ise.utils.functions.load_ml_data` with `except FileNotFoundError:` so that `KeyboardInterrupt`, `SystemExit`, and `MemoryError` are no longer silently swallowed.
+- `from ise import ISEFlow, ISEFlow_AIS, ISEFlow_GrIS` now works — names were in `__all__` but never imported, raising `ImportError`.
+- `ISEFlowGrISInputs._assign_model_configs` defaulted to the AIS model-configs JSON, so GrIS-only ISM names (e.g. `"AWI-ISSM1"`) raised `ValueError: Model name ... not found`. Added `gris_ismip6_model_configs_path` in `ise/utils/__init__.py` and switched the GrIS dataclass default. Regression test added.
+- Silenced `sklearn.exceptions.InconsistentVersionWarning` package-wide — bundled pretrained scalers were pickled with an older sklearn version but unpickle correctly.
+- Plugged file-handle leaks (`pickle.load(open(...))` → `with open(...) as f`) in `feature_engineer.scale_data()`, `FeatureEngineer.scale_data()`, and `unscale_output()` / `unscale_input()` in `ise/utils/functions.py`.
+- Replaced bare `except:` in `ise.utils.functions.load_ml_data` with `except FileNotFoundError:` so `KeyboardInterrupt`/`SystemExit`/`MemoryError` are no longer swallowed.
 
 ### Changed
-- `ProjectionProcessor` ocean-forcing warnings (AIS and GrIS) now list the directory, the expected NetCDF variable names, and the files that *were* found, instead of an opaque "Directory X does not contain N files." message.
-- Moved the in-body `from scipy.ndimage import uniform_filter1d` to the top of `ise/models/iseflow.py` next to the other module imports (style cleanup; PEP 8 E402).
+- `ProjectionProcessor` ocean-forcing warnings (AIS and GrIS) now list the directory, expected NetCDF variable names, and files actually found, instead of an opaque "Directory X does not contain N files." message.
+- Moved the in-body `from scipy.ndimage import uniform_filter1d` to the top of `ise/models/iseflow.py` (PEP 8 E402).
 
 ### Documentation
-- Full audit pass across `ise/` docstrings. Notable fixes:
-  - `ISEFlow.forward` removed a phantom `smooth_projection` argument that did not exist in the signature.
-  - `ISEFlow.predict` converted a misleading `Raises: Warning` clause into a proper Sphinx `Warns` block and expanded the description of how scaler resolution and smoothing interact.
-  - `ISEFlow.load` removed a stale `Raises: NotImplementedError` claim that no longer matched the implementation.
-  - `NormalizingFlow.fit` documented the previously undocumented `X_val`, `y_val`, `lr`, and `wd` arguments.
-  - `NormalizingFlow.aleatoric` corrected the return-shape claim (per-row std `(N,)`, not `(num_samples,)`).
-  - `LSTM.fit` added the previously undocumented `wandb_run` argument.
-  - `RobustScaler.save/load` and `LogScaler.save/load` gained docstrings (only `StandardScaler` had them).
-  - `unscale_output` / `unscale_input` corrected: they accept any sklearn scaler with `inverse_transform`, not only `MinMaxScaler`.
-- `docs/model_versions.rst`: corrected the GrIS v1.1.0 input list (`aSMB`, `aST`, `sector`, etc. — not the prior `smb_anomaly`, `st_anomaly`, `region` placeholder), and replaced an unverified `aogcm="MIROC6"` example with a real bundled name (`noresm1-m_rcp85`).
-- `.gitignore`: ignore `.bugs.md` (local bug-triage scratchpad produced during the docs audit).
-- `README.md` and `docs/index.rst`: replaced the GitHub Releases pointer with a dedicated **Manuscript code archives** section listing Zenodo DOIs for each publication (Variational LSTM, ISEFlow, and the in-review "Emulator-expanded projections" paper). Reflects the move from per-paper GitHub releases to the maintained `ise-py` package plus frozen Zenodo snapshots.
+- Full docstring audit across `ise/`. Notable fixes: removed phantom `smooth_projection` arg from `ISEFlow.forward`; converted `ISEFlow.predict`'s misleading `Raises: Warning` into a proper Sphinx `Warns` block; removed stale `Raises: NotImplementedError` from `ISEFlow.load`; documented previously-undocumented args (`NormalizingFlow.fit`'s `X_val`/`y_val`/`lr`/`wd`, `LSTM.fit`'s `wandb_run`); corrected `NormalizingFlow.aleatoric` return shape to `(N,)`; added `save/load` docstrings to `RobustScaler` and `LogScaler`; clarified that `unscale_output`/`unscale_input` accept any sklearn scaler with `inverse_transform`, not only `MinMaxScaler`.
+- `docs/model_versions.rst`: corrected the GrIS v1.1.0 input list (`aSMB`, `aST`, `sector`, etc.) and replaced an unverified `aogcm="MIROC6"` example with a real bundled name (`noresm1-m_rcp85`).
+- `README.md` and `docs/index.rst`: replaced the GitHub Releases pointer with a **Manuscript code archives** section listing Zenodo DOIs per publication, reflecting the move from per-paper GitHub releases to the maintained `ise-py` package plus frozen Zenodo snapshots.
+- `.gitignore`: ignore `.bugs.md` (local docs-audit scratchpad).
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project uses **two independent version numbers**:
 
 ### Added
 - `docs/index.rst` — PyPI, Python version, License, and CI badges to match `README.md`. Previously only the ReadTheDocs badge was shown.
+- `ise.models.pretrained.get_model_dir()` now prints a clear stderr message when ISEFlow weights are being downloaded from HuggingFace Hub for the first time (and another when the download finishes). When weights are already cached, the loader stays silent — previously the call could appear to hang while HF metadata sync ran.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ This project uses **two independent version numbers**:
 - `docs/index.rst` — PyPI, Python version, License, and CI badges to match `README.md`. Previously only the ReadTheDocs badge was shown.
 - `ise.models.pretrained.get_model_dir()` now prints a clear stderr message when ISEFlow weights are being downloaded from HuggingFace Hub for the first time (and another when the download finishes). When weights are already cached, the loader stays silent — previously the call could appear to hang while HF metadata sync ran.
 
+### Fixed
+- Silenced `sklearn.exceptions.InconsistentVersionWarning` package-wide. Bundled pretrained scalers were pickled with an older sklearn version but unpickle correctly; the warning was noise on every example run. Filter installed in `ise/__init__.py` next to the existing properscoring escape-sequence filter.
+- `feature_engineer.scale_data()` and `FeatureEngineer.scale_data()` leaked file handles by calling `pickle.load(open(...))` without a context manager — switched to `with open(...) as f` to close deterministically and clear `ResourceWarning` noise.
+
 ---
 
 ## [1.2.0] — 2026-05-11 (package) | Model: v1.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ This project uses **two independent version numbers**:
   - `RobustScaler.save/load` and `LogScaler.save/load` gained docstrings (only `StandardScaler` had them).
   - `unscale_output` / `unscale_input` corrected: they accept any sklearn scaler with `inverse_transform`, not only `MinMaxScaler`.
 - `docs/model_versions.rst`: corrected the GrIS v1.1.0 input list (`aSMB`, `aST`, `sector`, etc. — not the prior `smb_anomaly`, `st_anomaly`, `region` placeholder), and replaced an unverified `aogcm="MIROC6"` example with a real bundled name (`noresm1-m_rcp85`).
+- `.gitignore`: ignore `.bugs.md` (local bug-triage scratchpad produced during the docs audit).
 
 ---
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,13 +1,21 @@
 cff-version: 1.2.0
 message: "If you use this software, please cite it as below."
 type: software
-title: "ISE: Ice Sheet Emulator"
+title: "ise-py: Python package for ice sheet emulation and sea level projections"
+abstract: >
+  ise-py provides tools for training and analyzing ice sheet emulators, with a focus
+  on probabilistic sea level projections. The flagship model, ISEFlow, is a hybrid
+  normalizing-flow + deep-ensemble neural network emulator supporting both the Antarctic
+  Ice Sheet (18 sectors, 8 km resolution) and the Greenland Ice Sheet (6 regions,
+  5 km resolution) over the 2015–2100 projection period. ISEFlow produces sea level
+  projections with decomposed epistemic and aleatoric uncertainty quantification,
+  using ISMIP6-compatible climate forcings.
 authors:
   - family-names: Van Katwyk
     given-names: Peter
     email: pvankatwyk@gmail.com
     affiliation: Brown University
-version: 1.0.0
+version: 1.2.1
 date-released: "2026-05-06"
 url: "https://github.com/Brown-SciML/ise"
 repository-code: "https://github.com/Brown-SciML/ise"
@@ -17,12 +25,9 @@ keywords:
   - sea level projections
   - uncertainty quantification
   - normalizing flow
+  - deep ensemble
   - deep learning
   - ISMIP6
-references:
-  - type: article
-    title: "ISEFlow: A Flow-Based Neural Network Emulator for Improved Sea Level Projections and Uncertainty Quantification"
-    authors:
-      - family-names: Van Katwyk
-        given-names: Peter
-        affiliation: Brown University
+  - Antarctic Ice Sheet
+  - Greenland Ice Sheet
+  - climate modeling

--- a/CITATION.md
+++ b/CITATION.md
@@ -4,20 +4,20 @@ If you use this software in your research, please cite it as follows:
 
 ## Plain Text
 
-Van Katwyk, P. (2026). *ISE: Ice Sheet Emulator* (Version 1.1.0) [Software]. GitHub. https://github.com/Brown-SciML/ise
+Van Katwyk, P. (2026). *ise-py: Python package for ice sheet emulation and sea level projections* (Version 1.1.0) [Software]. GitHub. https://github.com/Brown-SciML/ise
 
 ## BibTeX
 
 ```bibtex
 @software{vankatwyk2026ise,
   author       = {Van Katwyk, Peter},
-  title        = {{ISE}: {Ice Sheet Emulator}},
+  title        = {{ise-py}: {Python package for ice sheet emulation and sea level projections}},
   year         = {2026},
-  version      = {1.1.0},
+  version      = {1.2.1},
   publisher    = {GitHub},
   url          = {https://github.com/Brown-SciML/ise},
-  note         = {Python package for training and analyzing ice sheet emulators,
-                  including ISEFlow, a hybrid flow-based neural network emulator
-                  for sea level projections and uncertainty quantification.}
+  note         = {Includes ISEFlow, a hybrid normalizing-flow + deep-ensemble neural network
+                  emulator for the Antarctic and Greenland ice sheets, producing probabilistic
+                  sea level projections with epistemic and aleatoric uncertainty quantification.}
 }
 ```

--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ This codebase has been used in peer-reviewed research, including:
 
 - *"A Variational LSTM Emulator of Sea Level Contribution From the Antarctic Ice Sheet"*
 - *"ISEFlow: A Flow-Based Neural Network Emulator for Improved Sea Level Projections and Uncertainty Quantification"*
+- *"Emulator-expanded projections reveal structure in Antarctic sea level uncertainty"* (in review)
 
-For replication details see the [Releases](https://github.com/Brown-SciML/ise/releases) section.
+Manuscript-specific code is archived on Zenodo — see [Manuscript code archives](#manuscript-code-archives) below for DOIs.
 
 **Documentation:** <https://ise.readthedocs.io/>
 
@@ -248,6 +249,29 @@ Run tests before submitting:
 ```sh
 pytest tests/
 ```
+
+---
+
+## Manuscript code archives
+
+The current `ise-py` package on PyPI is the actively maintained, versioned successor
+to the manuscript-specific codebases. Frozen snapshots of the code used in each
+publication are archived on Zenodo at the DOIs below:
+
+- **"A Variational LSTM Emulator of Sea Level Contribution From the Antarctic Ice Sheet"**
+  Peter Van Katwyk, Baylor Fox-Kemper, Helene Seroussi, Sophie Nowicki, Karianne Bergen.
+  DOI: [10.5281/zenodo.10416633](https://doi.org/10.5281/zenodo.10416633)
+
+- **"ISEFlow: A Flow-Based Neural Network Emulator for Improved Sea Level Projections and Uncertainty Quantification"**
+  Peter Van Katwyk, Baylor Fox-Kemper, Sophie Nowicki, Helene Seroussi, Karianne Bergen.
+  DOI: [10.5281/zenodo.14908114](https://doi.org/10.5281/zenodo.14908114)
+
+- **"Emulator-expanded projections reveal structure in Antarctic sea level uncertainty"** (in review)
+  Peter Van Katwyk, Baylor Fox-Kemper, Sophie Nowicki, Helene Seroussi, Karianne Bergen.
+  Data & code DOI: [10.5281/zenodo.19355381](https://doi.org/10.5281/zenodo.19355381)
+
+For new work, install the maintained package (`pip install ise-py`); use the Zenodo
+archives when you need to reproduce results from a specific paper.
 
 ---
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -55,9 +55,11 @@ This codebase has been used in peer-reviewed research, including:
   Sheet"*
 - *"ISEFlow: A Flow-Based Neural Network Emulator for Improved Sea Level
   Projections and Uncertainty Quantification"*
+- *"Emulator-expanded projections reveal structure in Antarctic sea level
+  uncertainty"* (in review)
 
-For replication details see the `Releases <https://github.com/Brown-SciML/ise/releases>`_
-section.
+Manuscript-specific code is archived on Zenodo — see
+`Manuscript code archives`_ below for DOIs.
 
 Installation
 ============
@@ -163,6 +165,32 @@ Run tests before submitting:
 .. code-block:: shell
 
    pytest tests/
+
+Manuscript code archives
+========================
+
+The current ``ise-py`` package on PyPI is the actively maintained, versioned
+successor to the manuscript-specific codebases. Frozen snapshots of the code
+used in each publication are archived on Zenodo at the DOIs below:
+
+- **"A Variational LSTM Emulator of Sea Level Contribution From the Antarctic
+  Ice Sheet"** — Peter Van Katwyk, Baylor Fox-Kemper, Helene Seroussi,
+  Sophie Nowicki, Karianne Bergen.
+  DOI: `10.5281/zenodo.10416633 <https://doi.org/10.5281/zenodo.10416633>`_
+
+- **"ISEFlow: A Flow-Based Neural Network Emulator for Improved Sea Level
+  Projections and Uncertainty Quantification"** — Peter Van Katwyk,
+  Baylor Fox-Kemper, Sophie Nowicki, Helene Seroussi, Karianne Bergen.
+  DOI: `10.5281/zenodo.14908114 <https://doi.org/10.5281/zenodo.14908114>`_
+
+- **"Emulator-expanded projections reveal structure in Antarctic sea level
+  uncertainty"** *(in review)* — Peter Van Katwyk, Baylor Fox-Kemper,
+  Sophie Nowicki, Helene Seroussi, Karianne Bergen.
+  Data & code DOI:
+  `10.5281/zenodo.19355381 <https://doi.org/10.5281/zenodo.19355381>`_
+
+For new work, install the maintained package (``pip install ise-py``); use the
+Zenodo archives when you need to reproduce results from a specific paper.
 
 Contact & Support
 =================

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,6 +3,23 @@ ISE Documentation
 
 .. image:: https://readthedocs.org/projects/ise/badge/?version=latest
    :target: https://ise.readthedocs.io/en/latest/
+   :alt: Documentation Status
+
+.. image:: https://badge.fury.io/py/ise-py.svg
+   :target: https://pypi.org/project/ise-py/
+   :alt: PyPI version
+
+.. image:: https://img.shields.io/badge/python-3.11+-blue.svg
+   :target: https://python.org
+   :alt: Python 3.11+
+
+.. image:: https://img.shields.io/badge/License-MIT-yellow.svg
+   :target: https://github.com/Brown-SciML/ise/blob/master/LICENSE.md
+   :alt: License: MIT
+
+.. image:: https://github.com/Brown-SciML/ise/actions/workflows/ci.yml/badge.svg
+   :target: https://github.com/Brown-SciML/ise/actions/workflows/ci.yml
+   :alt: CI
 
 **ISE** (Ice Sheet Emulator) is a Python package for training and running machine
 learning emulators of ice sheet models, with a focus on **ISEFlow** — a hybrid

--- a/docs/model_versions.rst
+++ b/docs/model_versions.rst
@@ -61,8 +61,9 @@ v1.1.0 — AIS + GrIS (current)
 
 .. code-block:: text
 
-   year, region,
-   smb_anomaly, st_anomaly, ocean_thermal_forcing, basin_runoff,
+   year, sector,
+   aSMB, aST, ocean_thermal_forcing, basin_runoff,
+   ice_shelf_fracture, ocean_sensitivity, standard_ocean_forcing,
    [ISM model characteristics]
 
 ---
@@ -153,7 +154,7 @@ If you have raw absolute climate values rather than pre-computed anomalies, use 
        ocean_thermal_forcing=otf,
        ocean_salinity=sal,
        ocean_temperature=temp,
-       aogcm="MIROC6",          # or custom_climatology={...}
+       aogcm="noresm1-m_rcp85",   # or custom_climatology={...}
        model_configs="AWI_PISM1",
        ice_shelf_fracture=False,
        ocean_sensitivity="medium",

--- a/ise/__init__.py
+++ b/ise/__init__.py
@@ -32,7 +32,19 @@ For questions contact Peter Van Katwyk at pvankatwyk@gmail.com.
 
 import warnings
 
+# Silence noisy third-party warnings that users cannot act on:
+# - properscoring uses an invalid escape sequence in a regex literal; harmless.
+# - sklearn InconsistentVersionWarning: bundled pretrained scalers (scaler_X.pkl,
+#   scaler_y.pkl) were pickled with an older sklearn version. They unpickle
+#   correctly for the linear scalers we use, so the warning is noise for users.
 warnings.filterwarnings("ignore", category=SyntaxWarning, module="properscoring")
+
+try:
+    from sklearn.exceptions import InconsistentVersionWarning as _InconsistentVersionWarning
+
+    warnings.filterwarnings("ignore", category=_InconsistentVersionWarning)
+except ImportError:
+    pass
 
 __all__ = [
     "ISEFlow",

--- a/ise/__init__.py
+++ b/ise/__init__.py
@@ -46,6 +46,8 @@ try:
 except ImportError:
     pass
 
+from ise.models import ISEFlow, ISEFlow_AIS, ISEFlow_GrIS
+
 __all__ = [
     "ISEFlow",
     "ISEFlow_AIS",

--- a/ise/data/feature_engineer.py
+++ b/ise/data/feature_engineer.py
@@ -271,8 +271,10 @@ class FeatureEngineer:
             self.y = self.data[[x for x in self.data.columns if "sle" in x]]
 
         if self.scaler_X_path is not None and self.scaler_y_path is not None:
-            scaler_X = pickle.load(open(self.scaler_X_path, "rb"))
-            scaler_y = pickle.load(open(self.scaler_y_path, "rb"))
+            with open(self.scaler_X_path, "rb") as f:
+                scaler_X = pickle.load(f)
+            with open(self.scaler_y_path, "rb") as f:
+                scaler_y = pickle.load(f)
 
             return scaler_X.transform(self.X), scaler_y.transform(self.y)
         elif self.scaler_X is not None and self.scaler_y is not None:
@@ -522,7 +524,8 @@ def scale_data(data, scaler_path):
     }
     column_order = data.columns
 
-    scaler = pickle.load(open(scaler_path, "rb"))
+    with open(scaler_path, "rb") as f:
+        scaler = pickle.load(f)
     columns_to_scale = scaler.get_feature_names_out()
     columns_not_to_scale = [c for c in data.columns if c not in columns_to_scale]
     data_to_scale = data[columns_to_scale]

--- a/ise/data/inputs.py
+++ b/ise/data/inputs.py
@@ -72,7 +72,7 @@ from dataclasses import dataclass
 import numpy as np
 import pandas as pd
 
-from ise.utils import ismip6_model_configs_path
+from ise.utils import gris_ismip6_model_configs_path, ismip6_model_configs_path
 
 
 @dataclass
@@ -1215,7 +1215,9 @@ class ISEFlowGrISInputs:
     def __repr__(self):
         return self.__str__()
 
-    def _assign_model_configs(self, model_name, characteristics_json=ismip6_model_configs_path):
+    def _assign_model_configs(
+        self, model_name, characteristics_json=gris_ismip6_model_configs_path
+    ):
         with open(characteristics_json) as file:
             characteristics = json.load(file)
 

--- a/ise/data/process.py
+++ b/ise/data/process.py
@@ -1287,7 +1287,10 @@ def process_AIS_oceanic_sectors(forcing_directory, grid_file):
 
         files = os.listdir(f"{directory}/1995-2100/")
         if len(files) != 3:
-            warnings.warn(f"Directory {directory} does not contain 3 files.")
+            warnings.warn(
+                f"Skipping {directory}/1995-2100/: expected 3 NetCDF files "
+                f"(thermal_forcing, salinity, temperature), found {len(files)}: {files}"
+            )
 
         thermal_forcing_file = [f for f in files if "thermal_forcing" in f][0]
         salinity_file = [f for f in files if "salinity" in f][0]
@@ -1404,7 +1407,10 @@ def process_GrIS_oceanic_sectors(forcing_directory, grid_file):
 
         files = os.listdir(f"{forcing_directory}/{directory}")
         if len(files) != 2:
-            warnings.warn(f"Directory {directory} does not contain 2 files.")
+            warnings.warn(
+                f"Skipping {forcing_directory}/{directory}: expected 2 NetCDF files "
+                f"(thermalforcing, basinrunoff), found {len(files)}: {files}"
+            )
 
         thermal_forcing_file = [f for f in files if "thermalforcing" in f.lower()][0]
         basin_runoff_file = [f for f in files if "basinrunoff" in f.lower()][0]

--- a/ise/data/scaler.py
+++ b/ise/data/scaler.py
@@ -259,6 +259,11 @@ class RobustScaler(nn.Module):
         return X * (self.iqr_ + 1e-8) + self.median_
 
     def save(self, path):
+        """Save the fitted median and IQR tensors to ``path`` via ``torch.save``.
+
+        Args:
+            path (str): Destination file path.
+        """
         torch.save(
             {
                 "median_": self.median_,
@@ -269,6 +274,14 @@ class RobustScaler(nn.Module):
 
     @staticmethod
     def load(path):
+        """Load a RobustScaler from disk.
+
+        Args:
+            path (str): Path to a checkpoint produced by ``RobustScaler.save()``.
+
+        Returns:
+            RobustScaler: A scaler with ``median_`` and ``iqr_`` restored.
+        """
         checkpoint = torch.load(path, weights_only=True)
         scaler = RobustScaler()
         scaler.median_ = checkpoint["median_"]
@@ -350,6 +363,11 @@ class LogScaler(nn.Module):
         return X_exp + self.min_value
 
     def save(self, path):
+        """Save the fitted ``epsilon`` and ``min_value`` to ``path`` via ``torch.save``.
+
+        Args:
+            path (str): Destination file path.
+        """
         torch.save(
             {
                 "epsilon": self.epsilon,
@@ -360,6 +378,14 @@ class LogScaler(nn.Module):
 
     @staticmethod
     def load(path):
+        """Load a LogScaler from disk.
+
+        Args:
+            path (str): Path to a checkpoint produced by ``LogScaler.save()``.
+
+        Returns:
+            LogScaler: A scaler with ``epsilon`` and ``min_value`` restored.
+        """
         checkpoint = torch.load(path, weights_only=True)
         scaler = LogScaler()
         scaler.epsilon = checkpoint["epsilon"]

--- a/ise/models/iseflow.py
+++ b/ise/models/iseflow.py
@@ -76,6 +76,7 @@ import warnings
 import numpy as np
 import pandas as pd
 import torch
+from scipy.ndimage import uniform_filter1d
 from sklearn.exceptions import InconsistentVersionWarning
 from torch import nn
 
@@ -1095,9 +1096,6 @@ class ISEFlow_GrIS_NF_v1_0_0(NormalizingFlow):
             output_size=self.output_size,
             num_flow_transforms=self.num_flow_transforms,
         )
-
-
-from scipy.ndimage import uniform_filter1d
 
 
 def smooth_projections(data, window_size, projection_length=86):

--- a/ise/models/iseflow.py
+++ b/ise/models/iseflow.py
@@ -242,23 +242,20 @@ class ISEFlow(torch.nn.Module):
         self,
         x,
     ):
-        """
-        Performs a forward pass through the hybrid emulator.
+        """Run a forward pass through the hybrid emulator.
 
         Args:
-            x (array-like): Input data.
-            smooth_projection (bool, optional): Whether to apply smoothing to projections. Defaults to False.
+            x (array-like): Input feature matrix with shape ``(N, num_features)``.
 
         Returns:
-            tuple: A tuple containing:
-                - prediction (numpy.ndarray): Model predictions.
-                - uncertainties (dict): Dictionary with keys:
-                    - 'total' (numpy.ndarray): Total uncertainty.
-                    - 'epistemic' (numpy.ndarray): Epistemic uncertainty.
-                    - 'aleatoric' (numpy.ndarray): Aleatoric uncertainty.
+            tuple: ``(prediction, uncertainties)`` where:
 
-        Raises:
-            Warning: If the model has not been trained.
+            - **prediction** (*numpy.ndarray*): Mean prediction across ensemble members.
+            - **uncertainties** (*dict*): Keys ``'total'``, ``'epistemic'``, ``'aleatoric'``
+              with numpy arrays giving per-row uncertainty in scaled (model) units.
+
+        Warns:
+            UserWarning: If the model has not been trained.
         """
 
         self.eval()
@@ -279,29 +276,31 @@ class ISEFlow(torch.nn.Module):
         return prediction, uncertainties
 
     def predict(self, x, output_scaler=True, smoothing_window=0):
-        """
-        Makes predictions using the trained hybrid emulator with optional smoothing.
+        """Predict SLE projections and uncertainties, applying inverse scaling and optional smoothing.
 
-        IMPORTANT: Smoothing is applied to the final unscaled predictions and uncertainties
-        to ensure smooth output curves.
+        Smoothing is applied to the final unscaled predictions and uncertainties so the
+        physical SLE curve is what gets smoothed (rather than scaled values).
 
         Args:
-            x (array-like): Input data.
-            output_scaler (bool or str, optional): Path to the output scaler or whether to apply scaling.
-                Defaults to True.
-            smoothing_window (int, optional): Size of the smoothing window. 0 means no smoothing.
-                Defaults to 0.
+            x (array-like): Input feature matrix with shape ``(N, num_features)``.
+            output_scaler (bool or str, optional): If ``True`` (default), loads the
+                scaler bundled with the pretrained model. If ``False``, returns
+                un-rescaled predictions. If a string, loads the sklearn scaler at
+                that path and uses it to inverse-transform the output.
+            smoothing_window (int, optional): Width of a centered moving-average
+                smoother applied to the unscaled predictions and uncertainties.
+                ``0`` (default) disables smoothing.
 
         Returns:
-            tuple: A tuple containing:
-                - unscaled_predictions (numpy.ndarray): Model predictions in the original scale.
-                - uncertainties (dict): Dictionary with keys:
-                    - 'total' (numpy.ndarray): Total uncertainty.
-                    - 'epistemic' (numpy.ndarray): Epistemic uncertainty.
-                    - 'aleatoric' (numpy.ndarray): Aleatoric uncertainty.
+            tuple: ``(unscaled_predictions, uncertainties)`` where:
 
-        Raises:
-            Warning: If no scaler path is provided.
+            - **unscaled_predictions** (*numpy.ndarray*): Predictions in mm SLE.
+            - **uncertainties** (*dict*): Keys ``'total'``, ``'epistemic'``, ``'aleatoric'``
+              with numpy arrays in mm SLE.
+
+        Warns:
+            UserWarning: If no scaler is available; predictions and uncertainties are
+                then returned in the model's scaled output space rather than mm SLE.
         """
         self.eval()
 
@@ -437,19 +436,19 @@ class ISEFlow(torch.nn.Module):
         deep_ensemble_path=None,
         normalizing_flow_path=None,
     ):
-        """
-        Loads a trained ISEFlow model from specified paths.
+        """Load a trained ISEFlow from saved deep ensemble and normalizing flow checkpoints.
+
+        Provide either ``model_dir`` (which expects ``deep_ensemble.pth`` and
+        ``normalizing_flow.pth`` files inside it) or both ``deep_ensemble_path``
+        and ``normalizing_flow_path`` explicitly.
 
         Args:
-            model_dir (str, optional): Directory containing the saved model. Defaults to None.
-            deep_ensemble_path (str, optional): Path to the saved deep ensemble model. Defaults to None.
-            normalizing_flow_path (str, optional): Path to the saved normalizing flow model. Defaults to None.
+            model_dir (str, optional): Directory containing the saved sub-model files.
+            deep_ensemble_path (str, optional): Explicit path to the saved deep ensemble.
+            normalizing_flow_path (str, optional): Explicit path to the saved normalizing flow.
 
         Returns:
-            ISEFlow: The loaded ISEFlow model.
-
-        Raises:
-            NotImplementedError: If an unsupported version is specified.
+            ISEFlow: The loaded model, with ``trained=True``.
         """
 
         if model_dir:

--- a/ise/models/lstm.py
+++ b/ise/models/lstm.py
@@ -227,6 +227,8 @@ class LSTM(nn.Module):
             patience (int, optional): Number of epochs to wait before stopping. Defaults to 10.
             verbose (bool, optional): Whether to print training progress. Defaults to True.
             dataclass (type, optional): Dataset class for handling data. Defaults to EmulatorDataset.
+            wandb_run (wandb.run, optional): Weights & Biases run for per-epoch metric logging.
+                Defaults to None.
 
         Raises:
             ValueError: If no loss function is provided.

--- a/ise/models/normalizing_flow.py
+++ b/ise/models/normalizing_flow.py
@@ -192,23 +192,27 @@ class NormalizingFlow(nn.Module):
         lr=1e-4,
         wd=1e-6,
     ):
-        """
-        Trains the normalizing flow model using maximum likelihood estimation.
+        """Train the normalizing flow via maximum likelihood (negative log-probability).
+
+        If ``checkpoint_path`` already exists, training resumes from the saved
+        epoch. After training, the best checkpoint is loaded back into the model
+        and the temporary file is deleted.
 
         Args:
-            X (array-like): Input features of shape (num_samples, num_features).
-            y (array-like): Target values of shape (num_samples, output_size).
+            X (array-like): Input features of shape ``(num_samples, num_features)``.
+            y (array-like): Target values of shape ``(num_samples, output_size)``.
+            X_val (array-like, optional): Validation features for early stopping.
+            y_val (array-like, optional): Validation targets for early stopping.
             epochs (int, optional): Number of training epochs. Defaults to 100.
             batch_size (int, optional): Batch size for training. Defaults to 64.
             save_checkpoints (bool, optional): Whether to save model checkpoints. Defaults to True.
-            checkpoint_path (str, optional): Path to save model checkpoints. Defaults to 'checkpoint.pt'.
+            checkpoint_path (str, optional): Path to save model checkpoints. Defaults to ``'checkpoint.pt'``.
             early_stopping (bool, optional): Whether to use early stopping. Defaults to True.
             patience (int, optional): Number of epochs to wait before early stopping. Defaults to 10.
             verbose (bool, optional): Whether to print training progress. Defaults to True.
             wandb_run (wandb.run, optional): Weights & Biases run for logging. Defaults to None.
-
-        Raises:
-            ValueError: If checkpoint loading fails.
+            lr (float, optional): AdamW learning rate. Defaults to ``1e-4``.
+            wd (float, optional): AdamW weight decay. Defaults to ``1e-6``.
         """
 
         if self.trained:
@@ -405,17 +409,19 @@ class NormalizingFlow(nn.Module):
         return self.base_distribution.sample(latent_dim, context=x).squeeze(2)
 
     def aleatoric(self, features, num_samples, batch_size=128):
-        """
-        Estimates aleatoric uncertainty by computing the standard deviation of multiple
-        samples drawn from the normalizing flow model.
+        """Estimate aleatoric uncertainty as the std across flow samples per input row.
+
+        For each input row, draws ``num_samples`` samples from the conditional flow
+        and returns the standard deviation across those samples. NaN samples are
+        ignored when computing the std.
 
         Args:
-            features (array-like or torch.Tensor): Input features for sampling.
-            num_samples (int): Number of samples per input feature set.
-            batch_size (int, optional): Batch size for processing features. Defaults to 128.
+            features (array-like or torch.Tensor): Input features of shape ``(N, num_features)``.
+            num_samples (int): Number of flow samples drawn per input row.
+            batch_size (int, optional): Number of rows processed per forward pass. Defaults to 128.
 
         Returns:
-            np.ndarray: Aleatoric uncertainty estimates of shape (num_samples,).
+            numpy.ndarray: Per-row aleatoric uncertainty, shape ``(N,)``.
         """
 
         features = to_tensor(features)

--- a/ise/models/pretrained/__init__.py
+++ b/ise/models/pretrained/__init__.py
@@ -11,9 +11,10 @@ loader falls back to those local paths transparently.
 """
 
 import os
+import sys
 
-from huggingface_hub import snapshot_download
-from huggingface_hub.utils import disable_progress_bars
+from huggingface_hub import snapshot_download, try_to_load_from_cache
+from huggingface_hub.utils import disable_progress_bars, enable_progress_bars
 
 HF_REPO_ID = "pvankatwyk/ISEFlow"
 
@@ -45,13 +46,30 @@ def get_model_dir(version: str, ice_sheet: str) -> str:
     """
     subfolder = _subfolder(version, ice_sheet)
     local_fallback = os.path.join(_LOCAL_PRETRAINED_DIR, "ISEFlow", subfolder)
+    already_cached = _is_cached(subfolder)
 
     try:
-        disable_progress_bars()
+        if already_cached:
+            # Quiet path: weights already on disk, suppress HF's progress bars.
+            disable_progress_bars()
+        else:
+            enable_progress_bars()
+            print(
+                f"[ise] Downloading ISEFlow {ice_sheet} {version} weights from "
+                f"HuggingFace Hub ({HF_REPO_ID})... (first-time only; cached afterwards)",
+                file=sys.stderr,
+                flush=True,
+            )
         local_dir = snapshot_download(
             repo_id=HF_REPO_ID,
             allow_patterns=[f"{subfolder}/**"],
         )
+        if not already_cached:
+            print(
+                f"[ise] Finished downloading ISEFlow {ice_sheet} {version} weights.",
+                file=sys.stderr,
+                flush=True,
+            )
         return os.path.join(local_dir, subfolder)
     except Exception:
         # Fall back to bundled weights (local dev or air-gapped HPC).
@@ -63,6 +81,19 @@ def get_model_dir(version: str, ice_sheet: str) -> str:
             "Install huggingface_hub and ensure internet access, or place "
             "the weights at the local path."
         )
+
+
+def _is_cached(subfolder: str) -> bool:
+    """Return True if the canonical weight files for this subfolder are already cached."""
+    sentinel_files = (
+        f"{subfolder}/deep_ensemble.pth",
+        f"{subfolder}/normalizing_flow.pth",
+    )
+    for filename in sentinel_files:
+        cached = try_to_load_from_cache(repo_id=HF_REPO_ID, filename=filename)
+        if not isinstance(cached, str):
+            return False
+    return True
 
 
 def _subfolder(version: str, ice_sheet: str) -> str:

--- a/ise/utils/__init__.py
+++ b/ise/utils/__init__.py
@@ -14,8 +14,13 @@ __all__ = [
     "get_device",
     "unscale_output",
     "ismip6_model_configs_path",
+    "gris_ismip6_model_configs_path",
 ]
 
 ismip6_model_configs_path = os.path.join(
     os.path.dirname(__file__), "..", "data", "data_files", "ismip6_model_configs.json"
+)
+
+gris_ismip6_model_configs_path = os.path.join(
+    os.path.dirname(__file__), "..", "data", "data_files", "GrIS_ismip6_model_configs.json"
 )

--- a/ise/utils/functions.py
+++ b/ise/utils/functions.py
@@ -186,7 +186,7 @@ def load_ml_data(data_directory: str, time_series: bool = True):
                 test_scenarios = pd.read_csv(
                     f"{data_directory}/ts_test_scenarios.csv"
                 ).values.tolist()
-            except:
+            except FileNotFoundError:
                 raise FileNotFoundError(
                     f'Files not found at {data_directory}. Format must be in format "ts_train_features.csv"'
                 )
@@ -860,7 +860,8 @@ def unscale_output(y, scaler_path):
 
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", category=InconsistentVersionWarning)
-        scaler = pkl.load(open(scaler_path, "rb"))
+        with open(scaler_path, "rb") as f:
+            scaler = pkl.load(f)
     y = scaler.inverse_transform(y)
     return y
 
@@ -884,7 +885,8 @@ def unscale_input(X, scaler_path):
 
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", category=InconsistentVersionWarning)
-        scaler = pkl.load(open(scaler_path, "rb"))
+        with open(scaler_path, "rb") as f:
+            scaler = pkl.load(f)
     column_order = X.columns
     cols_to_scale = scaler.get_feature_names_out()
     data_to_scale = X[cols_to_scale]

--- a/ise/utils/functions.py
+++ b/ise/utils/functions.py
@@ -41,7 +41,7 @@ Scaling / unscaling
 -------------------
 ``unscale_output(y, scaler_path)``   — inverse-transform y with a saved sklearn scaler.
 ``unscale_input(X, scaler_path)``    — inverse-transform X features (DataFrame only).
-``unscale_column(dataset, column)``  — revert MinMax scaling on ``year`` / ``sector`` columns back to their original ranges (2015-2100 and 1-18/1-6 respectively).
+``unscale_column(dataset, column)``  — revert MinMax scaling on ``year`` / ``sectors`` columns back to their original ranges (2015-2100 and 1-18 for AIS or 1-6 for GrIS).
 
 Post-processing
 ---------------
@@ -845,15 +845,17 @@ def to_tensor(x):
 
 
 def unscale_output(y, scaler_path):
-    """
-    Unscales a dataset using a previously saved MinMaxScaler.
+    """Inverse-transform a target array using a saved sklearn scaler (e.g. ``scaler_y.pkl``).
+
+    Works with any sklearn scaler that implements ``inverse_transform``
+    (``StandardScaler``, ``MinMaxScaler``, ``RobustScaler``, etc.).
 
     Args:
-        y (np.ndarray): The scaled data.
-        scaler_path (str): Path to the saved MinMaxScaler object.
+        y (np.ndarray): Scaled target values.
+        scaler_path (str): Path to a pickled sklearn scaler.
 
     Returns:
-        np.ndarray: The unscaled data.
+        np.ndarray: The inverse-transformed target values.
     """
 
     with warnings.catch_warnings():
@@ -864,15 +866,18 @@ def unscale_output(y, scaler_path):
 
 
 def unscale_input(X, scaler_path):
-    """
-    Unscales input features using a previously saved MinMaxScaler.
+    """Inverse-transform input features using a saved sklearn scaler (e.g. ``scaler_X.pkl``).
+
+    Only the columns listed in the scaler's ``feature_names_in_`` are inverse-transformed;
+    other columns pass through unchanged. Works with any sklearn scaler that exposes
+    ``get_feature_names_out`` (i.e. fitted on a DataFrame).
 
     Args:
-        X (pd.DataFrame): The scaled input features.
-        scaler_path (str): Path to the saved MinMaxScaler object.
+        X (pd.DataFrame): Scaled input features.
+        scaler_path (str): Path to a pickled sklearn scaler.
 
     Returns:
-        pd.DataFrame: The unscaled input features.
+        pd.DataFrame: The inverse-transformed features in the original column order.
     """
     if not isinstance(X, pd.DataFrame):
         raise NotImplementedError("Only pandas DataFrame input is currently supported.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ise-py"
-version = "1.2.0"
+version = "1.2.1"
 description = "ISE (Ice Sheet Emulator) — ISEFlow, a flow-based neural network emulator for sea level projections with uncertainty quantification."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/ise/data/test_inputs.py
+++ b/tests/ise/data/test_inputs.py
@@ -263,6 +263,33 @@ class TestISEFlowGrISInputs:
         df = inputs.to_df()
         assert "year" in df.columns
 
+    def test_model_configs_resolves_gris_only_name(self):
+        # "AWI-ISSM1" exists only in GrIS_ismip6_model_configs.json — if the
+        # GrIS dataclass falls back to the AIS file by mistake, this raises
+        # ValueError("Model name AWI-ISSM1 ... not found").
+        kwargs = _gris_kwargs()
+        for field in (
+            "numerics",
+            "ice_flow_model",
+            "initialization",
+            "initial_smb",
+            "velocity",
+            "bedrock_topography",
+            "surface_thickness",
+            "geothermal_heat_flux",
+            "res_min",
+            "res_max",
+            "initial_year",
+        ):
+            kwargs.pop(field, None)
+        kwargs["model_configs"] = "AWI-ISSM1"
+        inputs = ISEFlowGrISInputs(**kwargs)
+        # values are upper-cased by _map_args after assignment
+        assert inputs.numerics == "FE"
+        assert inputs.ice_flow_model == "HO"
+        assert inputs.initialization == "DAV"
+        assert inputs.geothermal_heat_flux == "G"
+
 
 # ---------------------------------------------------------------------------
 # Validation edge cases — guard against silent regressions in _check_inputs


### PR DESCRIPTION
### Added
- `docs/index.rst` — PyPI, Python version, License, and CI badges to match `README.md`.
- `ise.models.pretrained.get_model_dir()` prints stderr progress when ISEFlow weights are downloaded from HuggingFace Hub for the first time; stays silent on cached loads (previously could appear to hang during HF metadata sync).

### Fixed
- `from ise import ISEFlow, ISEFlow_AIS, ISEFlow_GrIS` now works — names were in `__all__` but never imported, raising `ImportError`.
- `ISEFlowGrISInputs._assign_model_configs` defaulted to the AIS model-configs JSON, so GrIS-only ISM names (e.g. `"AWI-ISSM1"`) raised `ValueError: Model name ... not found`. Added `gris_ismip6_model_configs_path` in `ise/utils/__init__.py` and switched the GrIS dataclass default. Regression test added.
- Silenced `sklearn.exceptions.InconsistentVersionWarning` package-wide — bundled pretrained scalers were pickled with an older sklearn version but unpickle correctly.
- Plugged file-handle leaks (`pickle.load(open(...))` → `with open(...) as f`) in `feature_engineer.scale_data()`, `FeatureEngineer.scale_data()`, and `unscale_output()` / `unscale_input()` in `ise/utils/functions.py`.
- Replaced bare `except:` in `ise.utils.functions.load_ml_data` with `except FileNotFoundError:` so `KeyboardInterrupt`/`SystemExit`/`MemoryError` are no longer swallowed.

### Changed
- `ProjectionProcessor` ocean-forcing warnings (AIS and GrIS) now list the directory, expected NetCDF variable names, and files actually found, instead of an opaque "Directory X does not contain N files." message.
- Moved the in-body `from scipy.ndimage import uniform_filter1d` to the top of `ise/models/iseflow.py` (PEP 8 E402).

### Documentation
- Full docstring audit across `ise/`. Notable fixes: removed phantom `smooth_projection` arg from `ISEFlow.forward`; converted `ISEFlow.predict`'s misleading `Raises: Warning` into a proper Sphinx `Warns` block; removed stale `Raises: NotImplementedError` from `ISEFlow.load`; documented previously-undocumented args (`NormalizingFlow.fit`'s `X_val`/`y_val`/`lr`/`wd`, `LSTM.fit`'s `wandb_run`); corrected `NormalizingFlow.aleatoric` return shape to `(N,)`; added `save/load` docstrings to `RobustScaler` and `LogScaler`; clarified that `unscale_output`/`unscale_input` accept any sklearn scaler with `inverse_transform`, not only `MinMaxScaler`.
- `docs/model_versions.rst`: corrected the GrIS v1.1.0 input list (`aSMB`, `aST`, `sector`, etc.) and replaced an unverified `aogcm="MIROC6"` example with a real bundled name (`noresm1-m_rcp85`).
- `README.md` and `docs/index.rst`: replaced the GitHub Releases pointer with a **Manuscript code archives** section listing Zenodo DOIs per publication, reflecting the move from per-paper GitHub releases to the maintained `ise-py` package plus frozen Zenodo snapshots.
- `.gitignore`: ignore `.bugs.md` (local docs-audit scratchpad).

---